### PR TITLE
Security audit for VPN detector fork

### DIFF
--- a/.github/workflows/security-guard.yml
+++ b/.github/workflows/security-guard.yml
@@ -1,0 +1,120 @@
+name: security-guard
+
+on:
+  pull_request:
+    branches: [main, master]
+  push:
+    branches: [main, master]
+
+# This workflow is the security baseline of the project.
+#
+# The core promise of VPN-Detector — and of the anti-VPN-apps scanner we
+# ship in the `detector/antivpn` package — is that NOTHING the tool sees
+# about the user's network leaves the device. The tool has no
+# `android.permission.INTERNET`, no HTTP client, no telemetry.
+#
+# This CI gate fails the build if anyone (intentionally or accidentally)
+# introduces a regression against that promise.
+
+jobs:
+  permissions-gate:
+    name: Manifest permissions must not grow
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Reject network / surveillance permissions
+        shell: bash
+        run: |
+          set -eu
+          manifest=app/src/main/AndroidManifest.xml
+          blocklist=(
+            "android.permission.INTERNET"
+            "android.permission.ACCESS_WIFI_STATE"
+            "android.permission.CHANGE_WIFI_STATE"
+            "android.permission.READ_PHONE_STATE"
+            "android.permission.READ_PHONE_NUMBERS"
+            "android.permission.FOREGROUND_SERVICE"
+            "android.permission.POST_NOTIFICATIONS"
+            "android.permission.ACCESS_FINE_LOCATION"
+            "android.permission.ACCESS_COARSE_LOCATION"
+            "android.permission.READ_CONTACTS"
+            "android.permission.READ_SMS"
+            "android.permission.RECORD_AUDIO"
+            "android.permission.CAMERA"
+            "android.permission.BIND_VPN_SERVICE"
+          )
+          failed=0
+          for perm in "${blocklist[@]}"; do
+            if grep -F -q "$perm" "$manifest"; then
+              echo "::error file=$manifest::forbidden permission present: $perm"
+              failed=1
+            fi
+          done
+          if [ $failed -ne 0 ]; then
+            echo "This workflow exists to preserve the core security guarantee of VPN-Detector."
+            echo "If you genuinely need one of these permissions, update the audit document"
+            echo "and this workflow in the same PR so the reviewer has to acknowledge it."
+            exit 1
+          fi
+
+  no-network-code:
+    name: No outbound networking code in app/detector
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Grep for forbidden networking primitives
+        shell: bash
+        run: |
+          set -eu
+          # Anything that could open an outbound connection. We lint
+          # only the main source sets — tests are allowed to stub HTTP.
+          paths=(app/src/main detector/src/main)
+          # Pattern list is intentionally broad. False positives should
+          # be surfaced as comments explaining why a match is safe.
+          patterns=(
+            'OkHttpClient'
+            'HttpURLConnection'
+            'okhttp3'
+            'retrofit2'
+            'java\.net\.URL\('
+            'DatagramSocket\('
+            'new Socket\('
+            'Socket\('
+            'FirebaseApp'
+            'Crashlytics'
+            'AnalyticsService'
+            'Amplitude'
+            'Mixpanel'
+            'AppsFlyer'
+          )
+          failed=0
+          for pat in "${patterns[@]}"; do
+            if grep -R -nE --include='*.kt' --include='*.java' --include='*.cpp' "$pat" "${paths[@]}" >/dev/null 2>&1; then
+              echo "::error::forbidden networking / telemetry pattern '$pat' in source:"
+              grep -R -nE --include='*.kt' --include='*.java' --include='*.cpp' "$pat" "${paths[@]}" || true
+              failed=1
+            fi
+          done
+          exit $failed
+
+  anti-vpn-assets-valid:
+    name: anti_vpn_apps.json is well-formed
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate curated JSON
+        shell: bash
+        run: |
+          set -eu
+          python3 - <<'PY'
+          import json, sys, pathlib
+          p = pathlib.Path("app/src/main/assets/anti_vpn_apps.json")
+          data = json.loads(p.read_text())
+          assert isinstance(data, list), "top-level must be a list"
+          for i, entry in enumerate(data):
+              for req in ("packageName", "label"):
+                  assert req in entry, f"entry {i} missing {req}"
+              sev = entry.get("severity", "medium")
+              assert sev in ("low", "medium", "high"), f"entry {i} bad severity {sev!r}"
+          print(f"OK: {len(data)} entries")
+          PY

--- a/app/src/main/assets/anti_vpn_apps.json
+++ b/app/src/main/assets/anti_vpn_apps.json
@@ -1,0 +1,163 @@
+[
+  {
+    "packageName": "com.netflix.mediaclient",
+    "label": "Netflix",
+    "category": "streaming",
+    "severity": "medium",
+    "evidence": "Public policy: blocks playback / shows proxy error when VPN/proxy is detected."
+  },
+  {
+    "packageName": "com.amazon.avod.thirdpartyclient",
+    "label": "Amazon Prime Video",
+    "category": "streaming",
+    "severity": "medium",
+    "evidence": "Public policy: restricts content and blocks known VPN IP ranges."
+  },
+  {
+    "packageName": "com.disney.disneyplus",
+    "label": "Disney+",
+    "category": "streaming",
+    "severity": "medium",
+    "evidence": "Public policy: enforces region via IP, blocks known VPN ranges."
+  },
+  {
+    "packageName": "com.hbo.hbonow",
+    "label": "HBO Max",
+    "category": "streaming",
+    "severity": "medium",
+    "evidence": "Public policy: region enforcement via IP reputation."
+  },
+  {
+    "packageName": "tv.twitch.android.app",
+    "label": "Twitch",
+    "category": "streaming",
+    "severity": "low",
+    "evidence": "Anti-fraud SDKs on mobile client are known to probe VPN status."
+  },
+  {
+    "packageName": "com.dazn",
+    "label": "DAZN",
+    "category": "streaming",
+    "severity": "high",
+    "evidence": "Blocks streams entirely when VPN is detected."
+  },
+  {
+    "packageName": "com.bbc.iplayer.android",
+    "label": "BBC iPlayer",
+    "category": "streaming",
+    "severity": "high",
+    "evidence": "UK-only; blocks on VPN / non-UK IP."
+  },
+  {
+    "packageName": "air.com.hulu.plus",
+    "label": "Hulu",
+    "category": "streaming",
+    "severity": "high",
+    "evidence": "US-only; explicit VPN/proxy block."
+  },
+  {
+    "packageName": "com.pandora.android",
+    "label": "Pandora",
+    "category": "streaming",
+    "severity": "medium",
+    "evidence": "Geo-restricted; VPN/proxy blocked."
+  },
+  {
+    "packageName": "com.spotify.music",
+    "label": "Spotify",
+    "category": "streaming",
+    "severity": "low",
+    "evidence": "Ties account region to IP; can lock accounts on persistent VPN use."
+  },
+  {
+    "packageName": "com.wellsfargo.mobile.android.wellsfargomobile",
+    "label": "Wells Fargo Mobile",
+    "category": "banking",
+    "severity": "high",
+    "evidence": "Banking apps commonly refuse login when VPN/proxy is detected."
+  },
+  {
+    "packageName": "com.chase.sig.android",
+    "label": "Chase Mobile",
+    "category": "banking",
+    "severity": "high",
+    "evidence": "Banking apps commonly refuse login when VPN/proxy is detected."
+  },
+  {
+    "packageName": "com.infonow.bofa",
+    "label": "Bank of America",
+    "category": "banking",
+    "severity": "high",
+    "evidence": "Banking apps commonly refuse login when VPN/proxy is detected."
+  },
+  {
+    "packageName": "com.citi.citimobile",
+    "label": "Citi Mobile",
+    "category": "banking",
+    "severity": "high",
+    "evidence": "Banking apps commonly refuse login when VPN/proxy is detected."
+  },
+  {
+    "packageName": "com.usaa.mobile.android.usaa",
+    "label": "USAA",
+    "category": "banking",
+    "severity": "high",
+    "evidence": "Banking apps commonly refuse login when VPN/proxy is detected."
+  },
+  {
+    "packageName": "com.idamob.tinkoff.android",
+    "label": "T-Bank (Tinkoff)",
+    "category": "banking",
+    "severity": "high",
+    "evidence": "Russian banking apps have been observed to restrict login over VPN."
+  },
+  {
+    "packageName": "ru.sberbankmobile",
+    "label": "SberBank Online",
+    "category": "banking",
+    "severity": "high",
+    "evidence": "Russian banking apps have been observed to restrict login over VPN."
+  },
+  {
+    "packageName": "ru.vtb24.mobilebanking.android",
+    "label": "VTB",
+    "category": "banking",
+    "severity": "high",
+    "evidence": "Russian banking apps have been observed to restrict login over VPN."
+  },
+  {
+    "packageName": "ru.alfabank.mobile.android",
+    "label": "Alfa-Bank",
+    "category": "banking",
+    "severity": "high",
+    "evidence": "Russian banking apps have been observed to restrict login over VPN."
+  },
+  {
+    "packageName": "ru.gosuslugi.pgu",
+    "label": "Gosuslugi",
+    "category": "government",
+    "severity": "high",
+    "evidence": "Russian state services portal; restrictive network posture."
+  },
+  {
+    "packageName": "com.bet365",
+    "label": "bet365",
+    "category": "gambling",
+    "severity": "high",
+    "evidence": "Gambling apps typically require real-IP geolocation and block VPN."
+  },
+  {
+    "packageName": "com.draftkings.sportsbook",
+    "label": "DraftKings Sportsbook",
+    "category": "gambling",
+    "severity": "high",
+    "evidence": "Regulated gambling: strict geo-fencing and VPN blocking."
+  },
+  {
+    "packageName": "com.fanduel.android.sportsbook",
+    "label": "FanDuel Sportsbook",
+    "category": "gambling",
+    "severity": "high",
+    "evidence": "Regulated gambling: strict geo-fencing and VPN blocking."
+  }
+]

--- a/app/src/main/java/com/cherepavel/vpndetector/ui/ReportFormatter.kt
+++ b/app/src/main/java/com/cherepavel/vpndetector/ui/ReportFormatter.kt
@@ -3,6 +3,9 @@ package com.cherepavel.vpndetector.ui
 import android.content.Context
 import com.cherepavel.vpndetector.R
 import com.cherepavel.vpndetector.detector.TunnelNameMatcher
+import com.cherepavel.vpndetector.model.AntiVpnAppHit
+import com.cherepavel.vpndetector.model.AntiVpnConfidence
+import com.cherepavel.vpndetector.model.AntiVpnSeverity
 import com.cherepavel.vpndetector.model.DetectionConfidence
 import com.cherepavel.vpndetector.model.DetectionSnapshot
 import com.cherepavel.vpndetector.model.DetectionStatus
@@ -267,6 +270,8 @@ object ReportFormatter {
                     )
                 )
             }
+
+            buildAntiVpnAppsSection(context, snapshot)?.let { add(it) }
 
             if (snapshot.workProfileCount > 1 || snapshot.isManagedProfile) {
                 add(
@@ -549,6 +554,77 @@ object ReportFormatter {
             normalized.contains("VPN", ignoreCase = true) -> "VPN"
             else -> softWrapToken(normalized)
         }
+    }
+
+    private fun buildAntiVpnAppsSection(
+        context: Context,
+        snapshot: DetectionSnapshot
+    ): DetailSection? {
+        val hits = snapshot.antiVpnApps.hits
+        if (hits.isEmpty()) return null
+
+        // Sort: CONFIRMED first, then LIKELY, then POSSIBLE; within a tier,
+        // HIGH severity first. Gives the user the most actionable items up top.
+        val sorted = hits.sortedWith(
+            compareBy(
+                { confidenceOrder(it.confidence) },
+                { severityOrder(it.severity) },
+                { it.label.lowercase() }
+            )
+        )
+
+        val body = buildString {
+            appendLine(context.getString(R.string.anti_vpn_section_warning))
+            appendLine()
+            for (hit in sorted) {
+                appendLine(formatAntiVpnHitLine(context, hit))
+            }
+        }.trimEnd()
+
+        val state = when {
+            sorted.any {
+                it.confidence == AntiVpnConfidence.CONFIRMED ||
+                        it.confidence == AntiVpnConfidence.LIKELY
+            } -> SignalState.POSITIVE // red — user should act
+            else -> SignalState.WARNING // orange — informational
+        }
+
+        return DetailSection(
+            title = context.getString(R.string.anti_vpn_section_title),
+            body = body,
+            state = state
+        )
+    }
+
+    private fun formatAntiVpnHitLine(context: Context, hit: AntiVpnAppHit): String {
+        val confidence = when (hit.confidence) {
+            AntiVpnConfidence.CONFIRMED -> context.getString(R.string.anti_vpn_confidence_confirmed)
+            AntiVpnConfidence.LIKELY -> context.getString(R.string.anti_vpn_confidence_likely)
+            AntiVpnConfidence.POSSIBLE -> context.getString(R.string.anti_vpn_confidence_possible)
+        }
+        val severity = when (hit.severity) {
+            AntiVpnSeverity.HIGH -> context.getString(R.string.anti_vpn_severity_high)
+            AntiVpnSeverity.MEDIUM -> context.getString(R.string.anti_vpn_severity_medium)
+            AntiVpnSeverity.LOW -> context.getString(R.string.anti_vpn_severity_low)
+        }
+        val signals = if (hit.signals.isEmpty()) {
+            ""
+        } else {
+            " — " + hit.signals.joinToString(", ")
+        }
+        return "• ${hit.label} (${hit.packageName}) [$confidence/$severity]$signals"
+    }
+
+    private fun confidenceOrder(c: AntiVpnConfidence): Int = when (c) {
+        AntiVpnConfidence.CONFIRMED -> 0
+        AntiVpnConfidence.LIKELY -> 1
+        AntiVpnConfidence.POSSIBLE -> 2
+    }
+
+    private fun severityOrder(s: AntiVpnSeverity): Int = when (s) {
+        AntiVpnSeverity.HIGH -> 0
+        AntiVpnSeverity.MEDIUM -> 1
+        AntiVpnSeverity.LOW -> 2
     }
 
     private fun softWrapToken(value: String): String {

--- a/app/src/main/java/com/cherepavel/vpndetector/ui/export/ReportExportBuilder.kt
+++ b/app/src/main/java/com/cherepavel/vpndetector/ui/export/ReportExportBuilder.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import com.cherepavel.vpndetector.BuildConfig
 import com.cherepavel.vpndetector.R
 import com.cherepavel.vpndetector.detector.TunnelNameMatcher
+import com.cherepavel.vpndetector.model.AntiVpnConfidence
+import com.cherepavel.vpndetector.model.AntiVpnScanMode
 import com.cherepavel.vpndetector.model.DetectionConfidence
 import com.cherepavel.vpndetector.model.DetectionSnapshot
 import com.cherepavel.vpndetector.model.DetectionStatus
@@ -35,6 +37,7 @@ object ReportExportBuilder {
             add(buildNativeSection(snapshot))
             add(buildJavaSection(snapshot))
             add(buildAppsSection(snapshot))
+            buildAntiVpnAppsSection(snapshot)?.let { add(it) }
             buildAdvancedSignalsSection(snapshot)?.let { add(it) }
         }
 
@@ -352,6 +355,79 @@ object ReportExportBuilder {
                     add(ExportItem.Paragraph("No VPN-related apps detected."))
                 }
             }
+        )
+    }
+
+    private fun buildAntiVpnAppsSection(snapshot: DetectionSnapshot): ExportSection? {
+        val result = snapshot.antiVpnApps
+        if (result.hits.isEmpty() && result.errors.isEmpty()) return null
+
+        val items = buildList {
+            add(
+                ExportItem.Paragraph(
+                    "Apps below are known or suspected to detect VPN state. " +
+                            "Consider disabling your VPN before launching them."
+                )
+            )
+            add(
+                ExportItem.Field(
+                    "Scan mode",
+                    if (result.scanMode == AntiVpnScanMode.DEEP) "deep (static DEX/SO scan)" else "fast (curated list only)"
+                )
+            )
+            if (result.scanMode == AntiVpnScanMode.DEEP) {
+                add(ExportItem.Field("Packages scanned", result.scannedPackageCount.toString()))
+            }
+
+            val confirmed = result.hits.filter { it.confidence == AntiVpnConfidence.CONFIRMED }
+            val likely = result.hits.filter { it.confidence == AntiVpnConfidence.LIKELY }
+            val possible = result.hits.filter { it.confidence == AntiVpnConfidence.POSSIBLE }
+
+            if (confirmed.isNotEmpty()) {
+                add(
+                    ExportItem.ListBlock(
+                        label = "Confirmed (curated list)",
+                        values = confirmed.map { hit ->
+                            val ev = hit.evidence?.let { " — $it" }.orEmpty()
+                            "${hit.label} (${hit.packageName}) [${hit.category}/${hit.severity}]$ev"
+                        }
+                    )
+                )
+            }
+            if (likely.isNotEmpty()) {
+                add(
+                    ExportItem.ListBlock(
+                        label = "Likely (score ≥ ${com.cherepavel.vpndetector.detector.antivpn.AntiVpnSignatures.SCORE_LIKELY})",
+                        values = likely.map { hit ->
+                            "${hit.label} (${hit.packageName}) score=${hit.score} — ${hit.signals.joinToString(", ")}"
+                        }
+                    )
+                )
+            }
+            if (possible.isNotEmpty()) {
+                add(
+                    ExportItem.ListBlock(
+                        label = "Possible",
+                        values = possible.map { hit ->
+                            "${hit.label} (${hit.packageName}) score=${hit.score} — ${hit.signals.joinToString(", ")}"
+                        }
+                    )
+                )
+            }
+
+            if (result.errors.isNotEmpty()) {
+                add(
+                    ExportItem.ListBlock(
+                        label = "Scan errors",
+                        values = result.errors.map { (pkg, err) -> "$pkg: $err" }
+                    )
+                )
+            }
+        }
+
+        return ExportSection(
+            title = "APPS THAT DETECT VPN",
+            items = items
         )
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -108,6 +108,15 @@
     <string name="managed_profile_body">Running inside a managed profile.</string>
     <string name="work_profile_count_body">%1$d user profiles detected. VPN apps in other profiles are not visible to this detector.</string>
 
+    <string name="anti_vpn_section_title">Apps that detect VPN</string>
+    <string name="anti_vpn_section_warning">These installed apps are known or suspected to detect VPN state and may block or degrade functionality. Consider disabling your VPN before launching them.</string>
+    <string name="anti_vpn_confidence_confirmed">confirmed</string>
+    <string name="anti_vpn_confidence_likely">likely</string>
+    <string name="anti_vpn_confidence_possible">possible</string>
+    <string name="anti_vpn_severity_high">high</string>
+    <string name="anti_vpn_severity_medium">medium</string>
+    <string name="anti_vpn_severity_low">low</string>
+
     <string name="author">cherepavel</string>
     <string name="repo_url">https://github.com/cherepavel/VPN-Detector</string>
     <string name="source_code_label">Source code:</string>

--- a/detector/build.gradle.kts
+++ b/detector/build.gradle.kts
@@ -36,4 +36,9 @@ kotlin {
 
 dependencies {
     implementation(libs.androidx.core.ktx)
+
+    testImplementation(libs.junit)
+    // org.json.JSONArray is stubbed on the JVM target — pull the real
+    // implementation so unit tests can parse the curated assets JSON.
+    testImplementation("org.json:json:20240303")
 }

--- a/detector/src/main/java/com/cherepavel/vpndetector/detector/DetectionEngine.kt
+++ b/detector/src/main/java/com/cherepavel/vpndetector/detector/DetectionEngine.kt
@@ -5,6 +5,8 @@ import android.net.ConnectivityManager
 import android.net.LinkProperties
 import android.net.Network
 import android.net.NetworkCapabilities
+import com.cherepavel.vpndetector.detector.antivpn.AntiVpnAppsDetector
+import com.cherepavel.vpndetector.model.AntiVpnScanMode
 import com.cherepavel.vpndetector.model.DetectionSnapshot
 import com.cherepavel.vpndetector.util.NetworkSignalAnalyzer
 import com.cherepavel.vpndetector.util.TransportInfoFormatter
@@ -16,6 +18,8 @@ class DetectionEngine(
     private val javaInterfacesDetector: JavaInterfacesDetector = JavaInterfacesDetector(),
     private val trackedAppsDetector: TrackedAppsDetector = TrackedAppsDetector(context),
     private val dynamicVpnAppsDetector: DynamicVpnAppsDetector = DynamicVpnAppsDetector(context),
+    private val antiVpnAppsDetector: AntiVpnAppsDetector = AntiVpnAppsDetector(context),
+    private val antiVpnScanMode: AntiVpnScanMode = AntiVpnScanMode.FAST,
 ) : IDetectionEngine {
 
     companion object {
@@ -74,6 +78,7 @@ class DetectionEngine(
         val trackedResult = trackedAppsDetector.detect()
         val installedVpnApps = trackedResult.installed.map { "${it.label} (${it.packageName})" }
         val dynamicVpnApps = dynamicVpnAppsDetector.detect()
+        val antiVpnResult = antiVpnAppsDetector.detect(antiVpnScanMode)
 
         val tunTypeInterfaces = nativeResult.allInterfaces.mapNotNull { block ->
             val firstLine = block.lineSequence().firstOrNull() ?: return@mapNotNull null
@@ -157,6 +162,7 @@ class DetectionEngine(
             knownVpnDnsMatches = knownVpnDnsMatches,
             workProfileCount = workProfileResult.profileCount,
             isManagedProfile = workProfileResult.isManagedProfile,
+            antiVpnApps = antiVpnResult,
             assessment = assessment
         )
     }

--- a/detector/src/main/java/com/cherepavel/vpndetector/detector/antivpn/AntiVpnAppsDetector.kt
+++ b/detector/src/main/java/com/cherepavel/vpndetector/detector/antivpn/AntiVpnAppsDetector.kt
@@ -1,0 +1,188 @@
+package com.cherepavel.vpndetector.detector.antivpn
+
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageManager
+import android.os.Build
+import com.cherepavel.vpndetector.model.AntiVpnAppHit
+import com.cherepavel.vpndetector.model.AntiVpnConfidence
+import com.cherepavel.vpndetector.model.AntiVpnDetectionResult
+import com.cherepavel.vpndetector.model.AntiVpnScanMode
+import com.cherepavel.vpndetector.model.AntiVpnSeverity
+import com.cherepavel.vpndetector.model.KnownAntiVpnApp
+
+/**
+ * Finds installed applications that look like they contain
+ * anti-VPN-detection logic, so the user can be warned to disable their
+ * VPN before using them.
+ *
+ * Two tiers:
+ *
+ *  1. **Curated list** ([KnownAntiVpnRepository]) — apps that are
+ *     publicly known/suspected to block on VPN. Any installed package
+ *     that matches an entry is reported with [AntiVpnConfidence.CONFIRMED].
+ *  2. **Static DEX scan** ([DexSignatureScanner]) — in
+ *     [AntiVpnScanMode.DEEP] mode only, installed non-system apps are
+ *     also scanned for byte-level signatures. Hits are reported as
+ *     `LIKELY` or `POSSIBLE` depending on score.
+ *
+ * This detector makes no network calls, requests no new permissions, and
+ * only reads files the OS already lets the caller read
+ * (`ApplicationInfo.sourceDir`).
+ */
+class AntiVpnAppsDetector(
+    private val context: Context,
+    private val scanner: DexSignatureScanner = DexSignatureScanner(),
+    private val repository: (Context) -> List<KnownAntiVpnApp> = KnownAntiVpnRepository::get
+) {
+
+    companion object {
+        /** Do not attempt to deep-scan more than this many apps per run. */
+        internal const val MAX_DEEP_SCAN_APPS: Int = 40
+    }
+
+    fun detect(mode: AntiVpnScanMode = AntiVpnScanMode.FAST): AntiVpnDetectionResult {
+        val known = repository(context)
+        val hits = linkedMapOf<String, AntiVpnAppHit>()
+        val errors = mutableMapOf<String, String>()
+
+        // Tier 1: curated list matches. Fast, deterministic, no IO.
+        for (app in known) {
+            val info = getApplicationInfoOrNull(app.packageName, onError = { err ->
+                if (err != PackageManager.NameNotFoundException::class.java.simpleName) {
+                    errors[app.packageName] = err
+                }
+            }) ?: continue
+
+            hits[app.packageName] = AntiVpnAppHit(
+                packageName = app.packageName,
+                label = app.label,
+                category = app.category,
+                severity = app.severity,
+                confidence = AntiVpnConfidence.CONFIRMED,
+                signals = listOf("Curated list: ${app.category}"),
+                score = 0,
+                evidence = app.evidence.ifBlank { null }
+            )
+            // We intentionally do not also deep-scan CONFIRMED apps — the
+            // curated entry is more reliable than any heuristic match.
+            info.hashCode() // keep `info` usage explicit for readability
+        }
+
+        if (mode == AntiVpnScanMode.FAST) {
+            return AntiVpnDetectionResult(
+                hits = hits.values.toList(),
+                scanMode = AntiVpnScanMode.FAST,
+                scannedPackageCount = 0,
+                errors = errors
+            )
+        }
+
+        // Tier 2: deep scan of non-curated, user-installed, non-system apps.
+        val candidates = listCandidateApps()
+            .filter { it.packageName !in hits.keys }
+            .take(MAX_DEEP_SCAN_APPS)
+
+        var scannedCount = 0
+        for (info in candidates) {
+            val path = info.sourceDir ?: continue
+            scannedCount++
+
+            val result = try {
+                scanner.scanApk(path)
+            } catch (t: Throwable) {
+                errors[info.packageName] = "scan: ${t.javaClass.simpleName}: ${t.message ?: ""}"
+                continue
+            }
+
+            if (result.score < AntiVpnSignatures.SCORE_POSSIBLE) continue
+
+            val confidence = if (result.score >= AntiVpnSignatures.SCORE_LIKELY) {
+                AntiVpnConfidence.LIKELY
+            } else {
+                AntiVpnConfidence.POSSIBLE
+            }
+
+            val label = loadLabel(info)
+            hits[info.packageName] = AntiVpnAppHit(
+                packageName = info.packageName,
+                label = label,
+                category = "unknown",
+                severity = confidenceToSeverity(confidence),
+                confidence = confidence,
+                signals = result.matches.map { it.label },
+                score = result.score,
+                evidence = null
+            )
+        }
+
+        return AntiVpnDetectionResult(
+            hits = hits.values.toList(),
+            scanMode = AntiVpnScanMode.DEEP,
+            scannedPackageCount = scannedCount,
+            errors = errors
+        )
+    }
+
+    private fun listCandidateApps(): List<ApplicationInfo> {
+        val pm = context.packageManager
+        val all = try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                pm.getInstalledApplications(PackageManager.ApplicationInfoFlags.of(0))
+            } else {
+                @Suppress("DEPRECATION")
+                pm.getInstalledApplications(0)
+            }
+        } catch (_: Throwable) {
+            emptyList()
+        }
+
+        return all.filter { info ->
+            // Skip system apps (including updated system apps) — those are
+            // not user-installed and rarely do VPN detection as part of
+            // the relevant threat model, while contributing huge scan
+            // volumes.
+            (info.flags and ApplicationInfo.FLAG_SYSTEM) == 0 &&
+                    info.packageName != context.packageName
+        }
+    }
+
+    private fun getApplicationInfoOrNull(
+        packageName: String,
+        onError: (String) -> Unit
+    ): ApplicationInfo? {
+        return try {
+            val pm = context.packageManager
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                pm.getApplicationInfo(packageName, PackageManager.ApplicationInfoFlags.of(0))
+            } else {
+                @Suppress("DEPRECATION")
+                pm.getApplicationInfo(packageName, 0)
+            }
+        } catch (_: PackageManager.NameNotFoundException) {
+            onError(PackageManager.NameNotFoundException::class.java.simpleName)
+            null
+        } catch (e: Throwable) {
+            onError("${e.javaClass.simpleName}: ${e.message ?: ""}")
+            null
+        }
+    }
+
+    private fun loadLabel(info: ApplicationInfo): String {
+        return try {
+            context.packageManager.getApplicationLabel(info).toString()
+        } catch (_: Throwable) {
+            info.packageName
+        }
+    }
+
+    private fun confidenceToSeverity(confidence: AntiVpnConfidence): AntiVpnSeverity {
+        // Heuristic hits don't have a real severity — we map by confidence
+        // so the UI still has a color to show.
+        return when (confidence) {
+            AntiVpnConfidence.CONFIRMED -> AntiVpnSeverity.HIGH
+            AntiVpnConfidence.LIKELY -> AntiVpnSeverity.MEDIUM
+            AntiVpnConfidence.POSSIBLE -> AntiVpnSeverity.LOW
+        }
+    }
+}

--- a/detector/src/main/java/com/cherepavel/vpndetector/detector/antivpn/AntiVpnSignatures.kt
+++ b/detector/src/main/java/com/cherepavel/vpndetector/detector/antivpn/AntiVpnSignatures.kt
@@ -1,0 +1,126 @@
+package com.cherepavel.vpndetector.detector.antivpn
+
+/**
+ * Static byte-level signatures used by [DexSignatureScanner] to flag
+ * installed applications whose compiled code looks like it performs
+ * VPN-presence checks.
+ *
+ * Rationale
+ * ---------
+ * DEX files keep **all references to framework classes and methods as
+ * plain UTF-8 strings** in their string table (R8/ProGuard cannot rename
+ * `Landroid/net/ConnectivityManager;` — that name is fixed by the Android
+ * runtime). String literals inside user code (`"tun0"`, `"wg0"`, SDK class
+ * prefixes) also typically survive obfuscation unmodified.
+ *
+ * So a byte-level search for a curated set of short markers gives a cheap
+ * and reasonably accurate first pass, without linking against dexlib2 or
+ * any heavyweight analyzer. The approach has false positives — any app
+ * that legitimately reads `ConnectivityManager` will match the weak
+ * signals — so we scale responses by total weight and only flag when
+ * several signals fire together.
+ *
+ * This file is the single source of truth for the scoring heuristic and
+ * is intentionally short and readable so it can be reviewed and tuned
+ * against real APKs.
+ */
+object AntiVpnSignatures {
+
+    /**
+     * A signature the scanner looks for as a raw UTF-8 substring of a
+     * classes*.dex or lib/*.so file.
+     *
+     * @param label human-readable name shown in the detection report
+     * @param pattern bytes to search for (ASCII, case-sensitive)
+     * @param weight score added to the target app's total when present.
+     *   Designed so that two strong signals (≥ 10) push the app into
+     *   `LIKELY`, a single strong + several weak hits reach `POSSIBLE`,
+     *   and only weak noise stays under both thresholds.
+     */
+    data class Signature(
+        val label: String,
+        val pattern: ByteArray,
+        val weight: Int
+    ) {
+        /** Stable identity for deduplication of human-readable hit labels. */
+        override fun equals(other: Any?): Boolean =
+            other is Signature && other.label == label
+
+        override fun hashCode(): Int = label.hashCode()
+    }
+
+    /** Threshold at or above which the scanner emits a `LIKELY` hit. */
+    const val SCORE_LIKELY: Int = 10
+
+    /** Lower bound for `POSSIBLE` (below this, the scan emits nothing). */
+    const val SCORE_POSSIBLE: Int = 5
+
+    private fun sig(label: String, needle: String, weight: Int): Signature =
+        Signature(label, needle.toByteArray(Charsets.UTF_8), weight)
+
+    /**
+     * Strong signals — the presence of any single one is a significant
+     * hint that the app specifically reasons about VPN state.
+     */
+    private val strong: List<Signature> = listOf(
+        // Explicit "is the connection NOT over a VPN?" check. This is the
+        // textbook anti-VPN API call and the single most discriminating
+        // marker we can find without decompiling.
+        sig("NET_CAPABILITY_NOT_VPN reference", "NET_CAPABILITY_NOT_VPN", 8),
+
+        // TRANSPORT_VPN constant - used with hasTransport(...) for both
+        // "require VPN" and "reject VPN" checks. Less unique than
+        // NOT_VPN but still a strong tell.
+        sig("TRANSPORT_VPN reference", "TRANSPORT_VPN", 6),
+
+        // Typical manually-hardcoded tunnel interface name literals.
+        // The Android SDK does not expose these as constants, so an app
+        // that ships them in its DEX is almost always doing manual
+        // `NetworkInterface` enumeration for anti-VPN purposes.
+        sig("tun0 literal", "tun0", 5),
+        sig("wg0 literal", "wg0", 5),
+        sig("ppp0 literal", "ppp0", 4)
+    )
+
+    /**
+     * Medium signals — individually harmless (every chat app touches
+     * ConnectivityManager), but weighted so that several of them
+     * together with at least one strong hit pushes into LIKELY.
+     */
+    private val medium: List<Signature> = listOf(
+        sig("hasTransport call", "hasTransport", 2),
+        sig("getAllNetworks call", "getAllNetworks", 2),
+        sig("getNetworkCapabilities call", "getNetworkCapabilities", 2),
+        sig("NetworkInterface.getNetworkInterfaces", "getNetworkInterfaces", 2),
+        sig("isUp call", "isUp", 1),
+
+        // Known anti-fraud / device-fingerprinting SDK package prefixes.
+        // Presence does not prove anti-VPN behaviour, but these SDKs are
+        // frequently the ones that ship VPN detectors.
+        sig("IPQualityScore SDK", "com/ipqualityscore", 3),
+        sig("ThreatMetrix SDK", "com/threatmetrix", 3),
+        sig("Fingerprint.com SDK", "io/fingerprint", 3),
+        sig("Arkose Labs SDK", "com/arkoselabs", 3),
+        sig("Incognia SDK", "com/incognia", 3),
+        sig("iovation SDK", "com/iovation", 3),
+        sig("Sift SDK", "com/sift", 2)
+    )
+
+    /**
+     * Native-library signals — scanned against `lib/<abi>/*.so` inside
+     * the APK. These cover apps that do VPN detection in C/C++ to evade
+     * Java-side reverse engineering.
+     */
+    private val native: List<Signature> = listOf(
+        sig("getifaddrs in native lib", "getifaddrs", 4),
+        sig("/proc/net/route read", "/proc/net/route", 5),
+        sig("/proc/net/ipv6_route read", "/proc/net/ipv6_route", 4),
+        sig("tun0 literal in native lib", "tun0", 3)
+    )
+
+    /** Signatures applied to DEX bytecode files. */
+    val dexSignatures: List<Signature> = strong + medium
+
+    /** Signatures applied to packaged native libraries. */
+    val nativeSignatures: List<Signature> = native
+}

--- a/detector/src/main/java/com/cherepavel/vpndetector/detector/antivpn/DexSignatureScanner.kt
+++ b/detector/src/main/java/com/cherepavel/vpndetector/detector/antivpn/DexSignatureScanner.kt
@@ -1,0 +1,180 @@
+package com.cherepavel.vpndetector.detector.antivpn
+
+import java.io.File
+import java.io.InputStream
+import java.util.zip.ZipFile
+
+/**
+ * Scans an installed APK for byte-level signatures from [AntiVpnSignatures]
+ * and returns an aggregate score together with the list of signals that
+ * fired.
+ *
+ * Security / privacy properties this class is responsible for:
+ *
+ *  * Runs **entirely offline.** No network I/O, no JNI, no reflection into
+ *    other processes — it only opens files that the OS already lets the
+ *    caller read (the base APK path returned by `PackageManager`).
+ *  * **Bounded in time and memory.** Each dex/lib entry is read in 64 KiB
+ *    chunks up to [MAX_ENTRY_BYTES]. Larger entries are skipped rather
+ *    than buffered into RAM. The scanner also honours a per-package
+ *    total byte budget ([MAX_TOTAL_BYTES_PER_APK]) so a pathological
+ *    multi-dex app can't lock up the UI thread.
+ *  * **Case-sensitive exact matching.** We are looking for framework
+ *    identifiers and hard-coded string literals, which are both
+ *    case-stable; avoiding normalization keeps false positives low.
+ */
+class DexSignatureScanner(
+    private val dexSignatures: List<AntiVpnSignatures.Signature> = AntiVpnSignatures.dexSignatures,
+    private val nativeSignatures: List<AntiVpnSignatures.Signature> = AntiVpnSignatures.nativeSignatures
+) {
+
+    companion object {
+        /** Hard limit on a single DEX/SO entry we are willing to scan. */
+        internal const val MAX_ENTRY_BYTES: Long = 32L * 1024 * 1024
+
+        /** Hard limit on total bytes scanned per APK. */
+        internal const val MAX_TOTAL_BYTES_PER_APK: Long = 96L * 1024 * 1024
+
+        /** Read buffer size for streaming zip entries through the matcher. */
+        private const val CHUNK_SIZE: Int = 64 * 1024
+
+        /**
+         * The maximum substring length we might need to match across a
+         * chunk boundary. We tail-carry this many trailing bytes into the
+         * next chunk so that a signature straddling the boundary is still
+         * found.
+         */
+        private val OVERLAP: Int =
+            (AntiVpnSignatures.dexSignatures + AntiVpnSignatures.nativeSignatures)
+                .maxOf { it.pattern.size } - 1
+    }
+
+    data class ScanResult(
+        val score: Int,
+        val matches: List<AntiVpnSignatures.Signature>,
+        val bytesScanned: Long,
+        val skipped: List<String>
+    )
+
+    /**
+     * Scan an APK at [apkPath]. Returns an empty score if the file cannot
+     * be opened (e.g. system app with restricted access) — errors are
+     * reported via [ScanResult.skipped], never thrown, so a single bad
+     * package cannot abort the whole run.
+     */
+    fun scanApk(apkPath: String): ScanResult {
+        val file = File(apkPath)
+        if (!file.exists() || !file.canRead()) {
+            return ScanResult(0, emptyList(), 0, listOf("unreadable: $apkPath"))
+        }
+
+        val matched = linkedMapOf<String, AntiVpnSignatures.Signature>()
+        val skipped = mutableListOf<String>()
+        var totalScanned: Long = 0
+
+        try {
+            ZipFile(file).use { zip ->
+                val entries = zip.entries()
+                while (entries.hasMoreElements()) {
+                    val entry = entries.nextElement()
+                    if (entry.isDirectory) continue
+
+                    val sigsToApply: List<AntiVpnSignatures.Signature>? = when {
+                        entry.name.endsWith(".dex", ignoreCase = true) -> dexSignatures
+                        entry.name.startsWith("lib/") && entry.name.endsWith(".so") -> nativeSignatures
+                        else -> null
+                    } ?: continue
+
+                    if (entry.size > MAX_ENTRY_BYTES) {
+                        skipped.add("too-large:${entry.name}")
+                        continue
+                    }
+
+                    if (totalScanned >= MAX_TOTAL_BYTES_PER_APK) {
+                        skipped.add("budget-exhausted:${entry.name}")
+                        continue
+                    }
+
+                    zip.getInputStream(entry).use { input ->
+                        val scanned = scanStream(input, sigsToApply!!, matched)
+                        totalScanned += scanned
+                    }
+                }
+            }
+        } catch (e: Throwable) {
+            skipped.add("error:${e.javaClass.simpleName}:${e.message ?: ""}")
+        }
+
+        val score = matched.values.sumOf { it.weight }
+        return ScanResult(
+            score = score,
+            matches = matched.values.toList(),
+            bytesScanned = totalScanned,
+            skipped = skipped
+        )
+    }
+
+    /**
+     * Streams [input] in chunks, applying a Boyer-Moore-style search for
+     * every signature. Found signatures are added to [collector] (keyed
+     * by label so duplicates in multi-dex apps only count once).
+     */
+    private fun scanStream(
+        input: InputStream,
+        signatures: List<AntiVpnSignatures.Signature>,
+        collector: LinkedHashMap<String, AntiVpnSignatures.Signature>
+    ): Long {
+        val buffer = ByteArray(CHUNK_SIZE + OVERLAP.coerceAtLeast(0))
+        var tailSize = 0 // carried over from previous chunk
+        var totalRead: Long = 0
+
+        while (true) {
+            val want = buffer.size - tailSize
+            val read = input.read(buffer, tailSize, want)
+            if (read <= 0) break
+
+            val dataSize = tailSize + read
+            totalRead += read
+
+            for (sig in signatures) {
+                if (collector.containsKey(sig.label)) continue
+                if (indexOf(buffer, dataSize, sig.pattern) >= 0) {
+                    collector[sig.label] = sig
+                }
+            }
+
+            // Carry the last OVERLAP bytes into the next chunk so a
+            // pattern straddling the boundary is still matched.
+            val carry = OVERLAP.coerceAtMost(dataSize)
+            if (carry > 0) {
+                System.arraycopy(buffer, dataSize - carry, buffer, 0, carry)
+            }
+            tailSize = carry
+        }
+
+        return totalRead
+    }
+
+    /**
+     * Plain byte-level substring search. Kept intentionally simple:
+     * signatures are short (≤ 32 bytes) and the data windows are small,
+     * so a naive O(n·m) scan is faster in practice than building a
+     * Boyer-Moore table for every call.
+     */
+    private fun indexOf(haystack: ByteArray, haystackSize: Int, needle: ByteArray): Int {
+        val n = needle.size
+        if (n == 0 || haystackSize < n) return -1
+        val first = needle[0]
+        val maxStart = haystackSize - n
+        var i = 0
+        while (i <= maxStart) {
+            if (haystack[i] == first) {
+                var j = 1
+                while (j < n && haystack[i + j] == needle[j]) j++
+                if (j == n) return i
+            }
+            i++
+        }
+        return -1
+    }
+}

--- a/detector/src/main/java/com/cherepavel/vpndetector/detector/antivpn/KnownAntiVpnRepository.kt
+++ b/detector/src/main/java/com/cherepavel/vpndetector/detector/antivpn/KnownAntiVpnRepository.kt
@@ -1,0 +1,61 @@
+package com.cherepavel.vpndetector.detector.antivpn
+
+import android.content.Context
+import com.cherepavel.vpndetector.model.AntiVpnSeverity
+import com.cherepavel.vpndetector.model.KnownAntiVpnApp
+import org.json.JSONArray
+
+/**
+ * Loads the curated list of apps known/suspected to perform anti-VPN checks
+ * from `assets/anti_vpn_apps.json`.
+ *
+ * Mirrors [com.cherepavel.vpndetector.detector.TrackedAppsRepository] — the
+ * same pattern of in-memory caching + lazy load from the APK asset stream.
+ *
+ * The list ships with the APK and is only updated via new app releases; the
+ * detector itself never fetches anything over the network.
+ */
+object KnownAntiVpnRepository {
+
+    private const val FILE_NAME = "anti_vpn_apps.json"
+
+    @Volatile
+    private var cached: List<KnownAntiVpnApp>? = null
+
+    fun get(context: Context): List<KnownAntiVpnApp> {
+        cached?.let { return it }
+
+        return try {
+            val json = context.applicationContext.assets
+                .open(FILE_NAME)
+                .bufferedReader()
+                .use { it.readText() }
+
+            parse(json).also { cached = it }
+        } catch (_: Exception) {
+            emptyList()
+        }
+    }
+
+    internal fun parse(json: String): List<KnownAntiVpnApp> {
+        val array = JSONArray(json)
+        return (0 until array.length()).map { i ->
+            val obj = array.getJSONObject(i)
+            KnownAntiVpnApp(
+                packageName = obj.getString("packageName"),
+                label = obj.getString("label"),
+                category = obj.optString("category", "unknown"),
+                severity = parseSeverity(obj.optString("severity", "medium")),
+                evidence = obj.optString("evidence", "")
+            )
+        }
+    }
+
+    private fun parseSeverity(raw: String): AntiVpnSeverity {
+        return when (raw.lowercase()) {
+            "high" -> AntiVpnSeverity.HIGH
+            "low" -> AntiVpnSeverity.LOW
+            else -> AntiVpnSeverity.MEDIUM
+        }
+    }
+}

--- a/detector/src/main/java/com/cherepavel/vpndetector/model/AntiVpnModels.kt
+++ b/detector/src/main/java/com/cherepavel/vpndetector/model/AntiVpnModels.kt
@@ -1,0 +1,76 @@
+package com.cherepavel.vpndetector.model
+
+/**
+ * How confident we are that a given installed app contains anti-VPN logic.
+ *
+ * - [CONFIRMED] — package is present in the curated `anti_vpn_apps.json` list.
+ * - [LIKELY] — strong static-signature match in the APK (e.g. explicit use of
+ *   NET_CAPABILITY_NOT_VPN or string literals `tun0`/`wg0`).
+ * - [POSSIBLE] — weaker aggregate signal from the DEX scan.
+ */
+enum class AntiVpnConfidence {
+    CONFIRMED,
+    LIKELY,
+    POSSIBLE
+}
+
+enum class AntiVpnSeverity {
+    /** App is known/suspected to block functionality when a VPN is detected. */
+    HIGH,
+
+    /** App is known/suspected to degrade service (e.g. region lock) when VPN is present. */
+    MEDIUM,
+
+    /** App merely detects / warns but keeps working. */
+    LOW
+}
+
+/**
+ * One curated entry in `anti_vpn_apps.json`.
+ */
+data class KnownAntiVpnApp(
+    val packageName: String,
+    val label: String,
+    val category: String,
+    val severity: AntiVpnSeverity,
+    val evidence: String
+)
+
+/**
+ * A detection hit — either from the curated list or from static APK scan.
+ */
+data class AntiVpnAppHit(
+    val packageName: String,
+    val label: String,
+    val category: String,
+    val severity: AntiVpnSeverity,
+    val confidence: AntiVpnConfidence,
+    /** Human-readable signals that contributed to the hit. */
+    val signals: List<String>,
+    /** Score from the static scanner (0 for CONFIRMED-only hits). */
+    val score: Int,
+    /** External source / citation for CONFIRMED entries. */
+    val evidence: String?
+)
+
+/**
+ * Result of running the anti-VPN detector.
+ *
+ * [scanMode] reflects what was actually executed (fast path vs deep scan);
+ * [scannedPackageCount] helps show the user how many apps were evaluated by
+ * the static scanner in deep mode.
+ */
+data class AntiVpnDetectionResult(
+    val hits: List<AntiVpnAppHit>,
+    val scanMode: AntiVpnScanMode,
+    val scannedPackageCount: Int,
+    val errors: Map<String, String>
+)
+
+enum class AntiVpnScanMode {
+    /** Only compare installed packages against the curated JSON list. */
+    FAST,
+
+    /** Also run static DEX / native lib signature scan on non-curated apps. */
+    DEEP
+}

--- a/detector/src/main/java/com/cherepavel/vpndetector/model/DetectionModels.kt
+++ b/detector/src/main/java/com/cherepavel/vpndetector/model/DetectionModels.kt
@@ -68,6 +68,7 @@ data class DetectionSnapshot(
     val knownVpnDnsMatches: List<String>,
     val workProfileCount: Int,
     val isManagedProfile: Boolean,
+    val antiVpnApps: AntiVpnDetectionResult,
     val assessment: DetectionAssessment
 ) {
     val unknownDynamicApps: List<String>

--- a/detector/src/test/java/com/cherepavel/vpndetector/detector/antivpn/DexSignatureScannerTest.kt
+++ b/detector/src/test/java/com/cherepavel/vpndetector/detector/antivpn/DexSignatureScannerTest.kt
@@ -1,0 +1,188 @@
+package com.cherepavel.vpndetector.detector.antivpn
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Assert.assertFalse
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+/**
+ * Unit tests for [DexSignatureScanner].
+ *
+ * We cannot build a real DEX file in a unit test, but the scanner
+ * operates on raw bytes, so we can validate behaviour by constructing
+ * synthetic ZIP archives whose `classes.dex` and `lib/*/lib*.so` entries
+ * contain the signature strings we expect the scanner to match.
+ *
+ * These tests exercise three things:
+ *
+ *   1. That individual signature classes (strong / medium / native) are
+ *      matched in the right kind of entry and not matched where they
+ *      don't belong.
+ *   2. That the aggregate score respects the LIKELY/POSSIBLE thresholds
+ *      from [AntiVpnSignatures].
+ *   3. That a stream longer than one chunk still matches a signature
+ *      straddling a chunk boundary (overlap-carry logic).
+ */
+class DexSignatureScannerTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private val scanner = DexSignatureScanner()
+
+    @Test
+    fun emptyApk_scoresZero() {
+        val apk = buildApk { /* empty */ }
+        val result = scanner.scanApk(apk.absolutePath)
+        assertEquals(0, result.score)
+        assertTrue(result.matches.isEmpty())
+    }
+
+    @Test
+    fun nonExistentPath_returnsZeroAndIsSkipped() {
+        val result = scanner.scanApk(tempFolder.root.absolutePath + "/missing.apk")
+        assertEquals(0, result.score)
+        assertTrue(result.skipped.isNotEmpty())
+    }
+
+    @Test
+    fun strongSignalInDex_pushesIntoLikely() {
+        val apk = buildApk {
+            putEntry("classes.dex", asciiPayload("header ... NET_CAPABILITY_NOT_VPN ... TRANSPORT_VPN ... tail"))
+        }
+        val result = scanner.scanApk(apk.absolutePath)
+        // NET_CAPABILITY_NOT_VPN (8) + TRANSPORT_VPN (6) = 14 >= SCORE_LIKELY (10)
+        assertTrue("expected score >= LIKELY, got ${result.score}", result.score >= AntiVpnSignatures.SCORE_LIKELY)
+        assertTrue(result.matches.any { it.label == "NET_CAPABILITY_NOT_VPN reference" })
+        assertTrue(result.matches.any { it.label == "TRANSPORT_VPN reference" })
+    }
+
+    @Test
+    fun onlyWeakSignals_stayBelowPossible() {
+        val apk = buildApk {
+            putEntry("classes.dex", asciiPayload("isUp"))
+        }
+        val result = scanner.scanApk(apk.absolutePath)
+        // "isUp" weight = 1, SCORE_POSSIBLE = 5
+        assertTrue("expected score < POSSIBLE, got ${result.score}", result.score < AntiVpnSignatures.SCORE_POSSIBLE)
+    }
+
+    @Test
+    fun tunLiteralAlone_reachesPossible() {
+        val apk = buildApk {
+            putEntry("classes.dex", asciiPayload("interface name: tun0"))
+        }
+        val result = scanner.scanApk(apk.absolutePath)
+        // tun0 = 5 which is exactly SCORE_POSSIBLE
+        assertTrue(result.score >= AntiVpnSignatures.SCORE_POSSIBLE)
+        assertTrue(result.matches.any { it.label == "tun0 literal" })
+    }
+
+    @Test
+    fun dexSignatures_notMatchedInNativeLib() {
+        // NET_CAPABILITY_NOT_VPN is a DEX signature, not a native one.
+        // Putting it in a .so must not score.
+        val apk = buildApk {
+            putEntry("lib/arm64-v8a/libfoo.so", asciiPayload("NET_CAPABILITY_NOT_VPN"))
+        }
+        val result = scanner.scanApk(apk.absolutePath)
+        assertEquals(0, result.score)
+    }
+
+    @Test
+    fun nativeLibSignatures_matched() {
+        val apk = buildApk {
+            putEntry(
+                "lib/arm64-v8a/libfoo.so",
+                asciiPayload("uses getifaddrs and reads /proc/net/route here")
+            )
+        }
+        val result = scanner.scanApk(apk.absolutePath)
+        assertTrue(result.matches.any { it.label == "getifaddrs in native lib" })
+        assertTrue(result.matches.any { it.label == "/proc/net/route read" })
+    }
+
+    @Test
+    fun randomTextFiles_areIgnored() {
+        // README / resources should not be scanned.
+        val apk = buildApk {
+            putEntry("assets/readme.txt", asciiPayload("NET_CAPABILITY_NOT_VPN appears here but shouldn't count"))
+            putEntry("res/layout/main.xml", asciiPayload("tun0"))
+        }
+        val result = scanner.scanApk(apk.absolutePath)
+        assertEquals(0, result.score)
+    }
+
+    @Test
+    fun signatureStraddlingChunkBoundary_isStillMatched() {
+        // Build a dex entry whose total size is larger than the scanner
+        // chunk buffer, placing the signature bytes exactly on the
+        // boundary between chunk N and chunk N+1.
+        val chunk = 64 * 1024
+        val filler = ByteArray(chunk - 5) { 'A'.code.toByte() }
+        val needle = "NET_CAPABILITY_NOT_VPN".toByteArray()
+        // Put filler (chunk - 5 bytes), then the needle (22 bytes) so the
+        // first 5 bytes of the needle land in chunk 1 and the rest in chunk 2,
+        // then some tail so we actually read into a second chunk.
+        val payload = ByteArray(filler.size + needle.size + 64)
+        System.arraycopy(filler, 0, payload, 0, filler.size)
+        System.arraycopy(needle, 0, payload, filler.size, needle.size)
+
+        val apk = buildApk {
+            putEntry("classes.dex", payload)
+        }
+        val result = scanner.scanApk(apk.absolutePath)
+        assertTrue(
+            "overlap carry failed: score=${result.score}, matches=${result.matches.map { it.label }}",
+            result.matches.any { it.label == "NET_CAPABILITY_NOT_VPN reference" }
+        )
+    }
+
+    @Test
+    fun duplicateSignatureInMultiDex_countedOnce() {
+        val apk = buildApk {
+            putEntry("classes.dex", asciiPayload("NET_CAPABILITY_NOT_VPN"))
+            putEntry("classes2.dex", asciiPayload("NET_CAPABILITY_NOT_VPN"))
+            putEntry("classes3.dex", asciiPayload("NET_CAPABILITY_NOT_VPN"))
+        }
+        val result = scanner.scanApk(apk.absolutePath)
+        assertEquals(1, result.matches.count { it.label == "NET_CAPABILITY_NOT_VPN reference" })
+        // Score equals the single-signal weight, not 3x of it.
+        assertEquals(8, result.score)
+    }
+
+    @Test
+    fun knownSdkPrefix_contributesMediumWeight() {
+        val apk = buildApk {
+            putEntry("classes.dex", asciiPayload("com/ipqualityscore/sdk/Client"))
+        }
+        val result = scanner.scanApk(apk.absolutePath)
+        assertTrue(result.matches.any { it.label == "IPQualityScore SDK" })
+        assertFalse(result.matches.any { it.label == "NET_CAPABILITY_NOT_VPN reference" })
+    }
+
+    // --- helpers ------------------------------------------------------------
+
+    private fun asciiPayload(s: String): ByteArray = s.toByteArray(Charsets.UTF_8)
+
+    private inner class ApkBuilder(private val zos: ZipOutputStream) {
+        fun putEntry(name: String, content: ByteArray) {
+            zos.putNextEntry(ZipEntry(name))
+            zos.write(content)
+            zos.closeEntry()
+        }
+    }
+
+    private fun buildApk(block: ApkBuilder.() -> Unit): File {
+        val file = tempFolder.newFile("synthetic-${System.nanoTime()}.apk")
+        ZipOutputStream(file.outputStream()).use { zos ->
+            ApkBuilder(zos).block()
+        }
+        return file
+    }
+}

--- a/detector/src/test/java/com/cherepavel/vpndetector/detector/antivpn/KnownAntiVpnRepositoryTest.kt
+++ b/detector/src/test/java/com/cherepavel/vpndetector/detector/antivpn/KnownAntiVpnRepositoryTest.kt
@@ -1,0 +1,88 @@
+package com.cherepavel.vpndetector.detector.antivpn
+
+import com.cherepavel.vpndetector.model.AntiVpnSeverity
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [KnownAntiVpnRepository.parse].
+ *
+ * The full `get(Context)` path can only run inside Android, but the JSON
+ * parser itself is pure and deserves its own regression tests so malformed
+ * or partial entries don't silently produce garbage at runtime.
+ */
+class KnownAntiVpnRepositoryTest {
+
+    @Test
+    fun parsesWellFormedEntries() {
+        val json = """
+            [
+              {
+                "packageName": "com.example.bank",
+                "label": "Example Bank",
+                "category": "banking",
+                "severity": "high",
+                "evidence": "public disclosure"
+              },
+              {
+                "packageName": "com.example.stream",
+                "label": "Example Stream",
+                "category": "streaming",
+                "severity": "medium",
+                "evidence": ""
+              }
+            ]
+        """.trimIndent()
+
+        val parsed = KnownAntiVpnRepository.parse(json)
+
+        assertEquals(2, parsed.size)
+        assertEquals("com.example.bank", parsed[0].packageName)
+        assertEquals(AntiVpnSeverity.HIGH, parsed[0].severity)
+        assertEquals("banking", parsed[0].category)
+        assertEquals("public disclosure", parsed[0].evidence)
+
+        assertEquals(AntiVpnSeverity.MEDIUM, parsed[1].severity)
+    }
+
+    @Test
+    fun unknownSeverity_defaultsToMedium() {
+        val json = """
+            [
+              {
+                "packageName": "com.example.app",
+                "label": "Example",
+                "category": "other",
+                "severity": "weird",
+                "evidence": ""
+              }
+            ]
+        """.trimIndent()
+
+        val parsed = KnownAntiVpnRepository.parse(json)
+        assertEquals(AntiVpnSeverity.MEDIUM, parsed[0].severity)
+    }
+
+    @Test
+    fun missingOptionalFields_useDefaults() {
+        // packageName and label are required; category, severity, evidence all optional.
+        val json = """
+            [
+              { "packageName": "com.example.app", "label": "Example" }
+            ]
+        """.trimIndent()
+
+        val parsed = KnownAntiVpnRepository.parse(json)
+        assertEquals(1, parsed.size)
+        assertEquals("unknown", parsed[0].category)
+        assertEquals(AntiVpnSeverity.MEDIUM, parsed[0].severity)
+        assertTrue(parsed[0].evidence.isEmpty())
+    }
+
+    @Test
+    fun emptyArray_returnsEmptyList() {
+        val parsed = KnownAntiVpnRepository.parse("[]")
+        assertTrue(parsed.isEmpty())
+    }
+}


### PR DESCRIPTION
Новый модуль detector/antivpn: поиск установленных приложений, которые проверяют наличие VPN, и предупреждение пользователя отключить VPN перед их запуском. Два уровня уверенности: CONFIRMED по курированному списку (app/src/main/assets/anti_vpn_apps.json) и LIKELY/POSSIBLE через байтовый скан classes*.dex и lib/*.so по сигнатурам NET_CAPABILITY_NOT_VPN, TRANSPORT_VPN, tun0/wg0, известных антифрод SDK.

UI получает новую секцию в отчёте и текстовом экспорте. Добавлены юнит-тесты скана и парсера JSON. CI-гард .github/workflows/security-guard.yml блокирует регрессию безопасности: запрещённые разрешения в манифесте, любой сетевой код или телеметрию, и валидирует курированный JSON. Никаких новых разрешений и ни одного исходящего соединения не добавлено.

https://claude.ai/code/session_01GJzm4rBddZiEKsnGHfz257